### PR TITLE
Remove mav_comm dependency in mav_planning_rviz

### DIFF
--- a/mav_planning_rviz/CMakeLists.txt
+++ b/mav_planning_rviz/CMakeLists.txt
@@ -1,65 +1,40 @@
 cmake_minimum_required(VERSION 3.14.4)
 project(mav_planning_rviz)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-# Set policy for 3.16 for CMP0076 defaulting to ON
 cmake_policy(VERSION 3.16)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-# These settings all stolen from visualization_tutorials:
-# This setting causes Qt's "MOC" generation to happen automatically.
-# set(CMAKE_AUTOMOC OFF)
-
 find_package(ament_cmake REQUIRED)
-find_package(grid_map_core REQUIRED)
-find_package(grid_map_ros REQUIRED)
-find_package(interactive_markers REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rviz_common REQUIRED)
-find_package(rviz_default_plugins REQUIRED)
-find_package(rviz_ogre_vendor REQUIRED)
-find_package(rviz_rendering REQUIRED)
-find_package(tf2 REQUIRED)
-
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
+find_package(grid_map_core REQUIRED)
+find_package(grid_map_msgs REQUIRED)
+find_package(grid_map_ros REQUIRED)
+find_package(interactive_markers REQUIRED)
 find_package(mavros_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(planner_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(trajectory_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets)
+find_package(rclcpp REQUIRED)
+find_package(rviz_common REQUIRED)
 find_package(visualization_msgs REQUIRED)
-
-find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Test Concurrent)
 
 set(mav_planning_rviz_plugins_headers_to_moc
   include/mav_planning_rviz/pose_widget.h
   include/mav_planning_rviz/planning_panel.h
   include/mav_planning_rviz/edit_button.h
 )
-
-# # I prefer the Qt signals and slots to avoid defining "emit", "slots",
-# # etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
-# add_definitions(-DQT_NO_KEYWORDS)
-
-# In case someone else struggles with getting panels to build, see this
-# solution:
-# https://answers.ros.org/question/215487/could-not-load-panel-in-rviz-pluginlibfactory-the-plugin-for-class/
 
 add_library(${PROJECT_NAME} SHARED
   src/planning_panel.cpp
@@ -72,41 +47,32 @@ add_library(${PROJECT_NAME} SHARED
 
 ament_target_dependencies(${PROJECT_NAME}
   grid_map_core
+  grid_map_msgs
   grid_map_ros
   interactive_markers
   pluginlib
   Qt5
   rclcpp
   rviz_common
-  rviz_default_plugins
-  rviz_ogre_vendor
-  rviz_rendering
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   ${Qt5Widgets_INCLUDE_DIRS}
-  ${OGRE_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME}
   Eigen3::Eigen
   ${geometry_msgs_TARGETS}
-  ${nav_msgs_TARGETS}
   ${mavros_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
   ${planner_msgs_TARGETS}
-  ${std_msgs_TARGETS}
-  ${std_srvs_TARGETS}
-  ${trajectory_msgs_TARGETS}
   ${visualization_msgs_TARGETS}
   rviz_common::rviz_common
 )
 
-# Causes the visibility macros to use dllexport rather than dllimport,
-# which is appropriate when building the dll but not consuming it.
-# TODO: Make this specific to this project (not rviz default plugins)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
@@ -119,15 +85,13 @@ target_link_libraries(standalone_test PUBLIC
   ${PROJECT_NAME}
 )
 
-# Install
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
 )
 
 install(
-  TARGETS
-  ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -144,8 +108,7 @@ ament_export_dependencies(
 )
 
 install(
-  TARGETS
-  standalone_test
+  TARGETS standalone_test
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -154,10 +117,5 @@ install(DIRECTORY
   rviz
   DESTINATION share/${PROJECT_NAME}/
 )
-
-if(BUILD_TESTING)
-  # find_package(ament_lint_auto REQUIRED)
-  # ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_package()

--- a/mav_planning_rviz/CMakeLists.txt
+++ b/mav_planning_rviz/CMakeLists.txt
@@ -35,7 +35,9 @@ find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(tf2 REQUIRED)
 
-find_package(mav_msgs REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(mavros_msgs REQUIRED)
 find_package(planner_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -86,11 +88,13 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   ${Qt5Widgets_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}
-  ${mav_msgs_INCLUDE_DIRS}/..
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${mav_msgs_TARGETS}
+  Eigen3::Eigen
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
   ${mavros_msgs_TARGETS}
   ${planner_msgs_TARGETS}
   ${std_msgs_TARGETS}

--- a/mav_planning_rviz/include/mav_planning_rviz/edit_button.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/edit_button.h
@@ -4,7 +4,6 @@
 #ifndef Q_MOC_RUN
 #include <QPushButton>
 #include <QWidget>
-#include <mav_msgs/eigen_mav_msgs.hpp>
 #endif
 
 namespace mav_planning_rviz {

--- a/mav_planning_rviz/include/mav_planning_rviz/planning_interactive_markers.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_interactive_markers.h
@@ -2,16 +2,15 @@
 #define MAV_PLANNING_RVIZ_PLANNING_INTERACTIVE_MARKERS_H_
 
 #include <functional>
+#include <geometry_msgs/msg/pose.hpp>
 #include <interactive_markers/interactive_marker_server.hpp>
-#include <mav_msgs/conversions.hpp>
-#include <mav_msgs/eigen_mav_msgs.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace mav_planning_rviz {
 
 class PlanningInteractiveMarkers {
  public:
-  typedef std::function<void(const mav_msgs::EigenTrajectoryPoint& pose)> PoseUpdatedFunctionType;
+  typedef std::function<void(const geometry_msgs::msg::Pose& pose)> PoseUpdatedFunctionType;
 
   PlanningInteractiveMarkers(rclcpp::Node::SharedPtr node);
 
@@ -25,13 +24,13 @@ class PlanningInteractiveMarkers {
   void initialize();
 
   // Functions to interface with the set_pose marker:
-  void enableSetPoseMarker(const mav_msgs::EigenTrajectoryPoint& pose);
+  void enableSetPoseMarker(const geometry_msgs::msg::Pose& pose);
   void disableSetPoseMarker();
-  void setPose(const mav_msgs::EigenTrajectoryPoint& pose);
+  void setPose(const geometry_msgs::msg::Pose& pose);
 
   // Functions to interact with markers from the marker map (no controls):
-  void enableMarker(const std::string& id, const mav_msgs::EigenTrajectoryPoint& pose);
-  void updateMarkerPose(const std::string& id, const mav_msgs::EigenTrajectoryPoint& pose);
+  void enableMarker(const std::string& id, const geometry_msgs::msg::Pose& pose);
+  void updateMarkerPose(const std::string& id, const geometry_msgs::msg::Pose& pose);
   void disableMarker(const std::string& id);
 
   void processSetPoseFeedback(const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);

--- a/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
@@ -5,6 +5,7 @@
 //! @todo(srmainwaring) prevent race condition with async service calls
 #include <QGroupBox>
 #include <mutex>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <planner_msgs/msg/navigation_status.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -50,7 +51,7 @@ class PlanningPanel : public rviz_common::Panel {
   void registerEditButton(EditButton* button);
 
   // Callback from ROS when the pose updates:
-  void updateInteractiveMarkerPose(const mav_msgs::EigenTrajectoryPoint& pose);
+  void updateInteractiveMarkerPose(const geometry_msgs::msg::Pose& pose);
   // And when we get robot odometry:
   void odometryCallback(const nav_msgs::msg::Odometry& msg);
 
@@ -64,7 +65,7 @@ class PlanningPanel : public rviz_common::Panel {
   void setPlannerName();
   void startEditing(const std::string& id);
   void finishEditing(const std::string& id);
-  void widgetPoseUpdated(const std::string& id, mav_msgs::EigenTrajectoryPoint& pose);
+  void widgetPoseUpdated(const std::string& id, geometry_msgs::msg::Pose& pose);
   void callPlannerService();
   void callPublishPath();
   void setGoalService();

--- a/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
@@ -2,80 +2,55 @@
 #define MAV_PLANNING_RVIZ_PLANNING_PANEL_H_
 
 #ifndef Q_MOC_RUN
-//! @todo(srmainwaring) prevent race condition with async service calls
 #include <QGroupBox>
 #include <mutex>
-#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <planner_msgs/msg/navigation_status.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
 
-#include "mav_planning_rviz/edit_button.h"
 #include "mav_planning_rviz/goal_marker.h"
 #include "mav_planning_rviz/planning_interactive_markers.h"
-#include "mav_planning_rviz/pose_widget.h"
 #endif
 
 class QLineEdit;
 class QCheckBox;
 class QComboBox;
+class QPushButton;
+
 namespace mav_planning_rviz {
 
 enum PLANNER_STATE { HOLD = 1, NAVIGATE = 2, ROLLOUT = 3, ABORT = 4, RETURN = 5 };
 enum FLIGHT_STACK { FLIGHT_STACK_NONE = 0, PX4 = 1, ARDUPILOT = 2 };
 
 class PlanningPanel : public rviz_common::Panel {
-  // This class uses Qt slots and is a subclass of QObject, so it needs
-  // the Q_OBJECT macro.
   Q_OBJECT
  public:
-  // QWidget subclass constructors usually take a parent widget
-  // parameter (which usually defaults to 0).  At the same time,
-  // pluginlib::ClassLoader creates instances by calling the default
-  // constructor (with no arguments).  Taking the parameter and giving
-  // a default of 0 lets the default constructor work and also lets
-  // someone using the class for something else to pass in a parent
-  // widget as they normally would with Qt.
   explicit PlanningPanel(QWidget* parent = 0);
 
-  // Now we declare overrides of rviz::Panel functions for saving and
-  // loading data from the config file.  Here the data is the
-  // topic name.
   virtual void load(const rviz_common::Config& config);
   virtual void save(rviz_common::Config config) const;
   virtual void onInitialize();
-
-  // All the settings to manage pose <-> edit mapping.
-  void registerPoseWidget(PoseWidget* widget);
-  void registerEditButton(EditButton* button);
 
   // Callback from ROS when the pose updates:
   void updateInteractiveMarkerPose(const geometry_msgs::msg::Pose& pose);
   // And when we get robot odometry:
   void odometryCallback(const nav_msgs::msg::Odometry& msg);
-
   void plannerstateCallback(const planner_msgs::msg::NavigationStatus& msg);
 
-  // Next come a couple of public Qt slots.
  public Q_SLOTS:
   void updatePlannerName();
   void updateFlightStack();
   void updatePlanningBudget();
   void setPlannerName();
-  void startEditing(const std::string& id);
-  void finishEditing(const std::string& id);
-  void widgetPoseUpdated(const std::string& id, geometry_msgs::msg::Pose& pose);
   void callPlannerService();
-  void callPublishPath();
   void setGoalService();
   void setPlanningBudgetService();
   void setStartService();
   void setStartLoiterService();
   void setCurrentSegmentService();
-  void setPathService();
   void publishWaypoint();
-  void publishToController();
   void terrainAlignmentStateChanged(int state);
   void EnableMaxAltitude();
   void DisableMaxAltitude();
@@ -85,10 +60,7 @@ class PlanningPanel : public rviz_common::Panel {
   void setPlannerModeServiceReturn();
 
  protected:
-  // Set up the layout, only called by the constructor.
   void createLayout();
-  void setNamespace(const QString& new_namespace);
-  void setOdometryTopic(const QString& new_odometry_topic);
   void setPlanningBudget(const QString& new_planning_budget);
   void setMaxAltitudeConstrant(bool set_constraint);
   void callSetPlannerStateService(std::string service_name, const int mode);
@@ -98,54 +70,37 @@ class PlanningPanel : public rviz_common::Panel {
 
   // ROS Stuff:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr waypoint_pub_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr controller_pub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_sub_;
   rclcpp::Subscription<planner_msgs::msg::NavigationStatus>::SharedPtr planner_state_sub_;
 
   std::shared_ptr<GoalMarker> goal_marker_;
 
-  //! @todo(srmainwaring) prevent race condition with async service calls
-  std::mutex node_mutex_;  // protects node_
+  std::mutex node_mutex_;
 
   // QT stuff:
-  QLineEdit* namespace_editor_;
   QLineEdit* planner_name_editor_;
   QComboBox* flight_stack_combobox_;
-  QLineEdit* odometry_topic_editor_;
   QLineEdit* planning_budget_editor_;
   QCheckBox* terrain_align_checkbox_;
-  PoseWidget* start_pose_widget_;
-  PoseWidget* goal_pose_widget_;
   QPushButton* planner_service_button_;
   QPushButton* set_goal_button_;
   QPushButton* set_start_button_;
   QPushButton* set_current_loiter_button_;
   QPushButton* set_current_segment_button_;
   QPushButton* trigger_planning_button_;
-  QPushButton* update_path_button_;
   QPushButton* waypoint_button_;
   QPushButton* max_altitude_button_enable_;
-  std::vector<QPushButton*> set_planner_state_buttons_;
   QPushButton* max_altitude_button_disable_;
-  QPushButton* controller_button_;
   QPushButton* load_terrain_button_;
+  std::vector<QPushButton*> set_planner_state_buttons_;
 
-  // Keep track of all the pose <-> button widgets as they're related:
-  std::map<std::string, PoseWidget*> pose_widget_map_;
-  std::map<std::string, EditButton*> edit_button_map_;
   // ROS state:
   PlanningInteractiveMarkers interactive_markers_;
 
   // QT state:
-  QString namespace_;
   QString planner_name_;
   QString planning_budget_value_{"100.0"};
-  QString odometry_topic_;
   bool align_terrain_on_load_{true};
-
-  // Other state:
-  std::string currently_editing_;
 
   // Select flight stack (affects offboard/guided and RTL commands)
   QStringList flight_stack_names_ = {"px4", "ardupilot"};

--- a/mav_planning_rviz/include/mav_planning_rviz/pose_widget.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/pose_widget.h
@@ -6,7 +6,7 @@
 #include <QLineEdit>
 #include <QStringList>
 #include <QTableWidget>
-#include <mav_msgs/eigen_mav_msgs.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #endif
 
 class QLineEdit;
@@ -21,13 +21,13 @@ class PoseWidget : public QWidget {
   std::string id() const { return id_; }
   void setId(const std::string& id) { id_ = id; }
 
-  void getPose(mav_msgs::EigenTrajectoryPoint* point) const;
-  void setPose(const mav_msgs::EigenTrajectoryPoint& point);
+  void getPose(geometry_msgs::msg::Pose* pose) const;
+  void setPose(const geometry_msgs::msg::Pose& pose);
 
   virtual QSize sizeHint() const { return table_widget_->sizeHint(); }
 
  Q_SIGNALS:
-  void poseUpdated(const std::string& id, mav_msgs::EigenTrajectoryPoint& pose);
+  void poseUpdated(const std::string& id, geometry_msgs::msg::Pose& pose);
 
  public Q_SLOTS:
   void itemChanged(QTableWidgetItem* item);

--- a/mav_planning_rviz/package.xml
+++ b/mav_planning_rviz/package.xml
@@ -21,7 +21,9 @@
   <depend>rviz_rendering</depend>
   <depend>tf2</depend>
 
-  <depend>mav_msgs</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>mavros_msgs</depend>
   <depend>planner_msgs</depend>
   <depend>std_msgs</depend>

--- a/mav_planning_rviz/package.xml
+++ b/mav_planning_rviz/package.xml
@@ -11,33 +11,24 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>qtbase5-dev</build_depend>
 
-  <depend>grid_map_core</depend>
-  <depend>grid_map_ros</depend>
-  <depend>interactive_markers</depend>
-  <depend>rclcpp</depend>
-  <depend>rviz_common</depend>
-  <depend>rviz_default_plugins</depend>
-  <depend>rviz_ogre_vendor</depend>
-  <depend>rviz_rendering</depend>
-  <depend>tf2</depend>
-
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>nav_msgs</depend>
+  <depend>grid_map_core</depend>
+  <depend>grid_map_msgs</depend>
+  <depend>grid_map_ros</depend>
+  <depend>interactive_markers</depend>
   <depend>mavros_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>planner_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>trajectory_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rviz_common</depend>
   <depend>visualization_msgs</depend>
 
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
-  <exec_depend>libqt5-opengl</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>
-    <!-- <rviz plugin="${prefix}/plugin_description.xml"/> -->
   </export>
 </package>

--- a/mav_planning_rviz/src/planning_interactive_markers.cpp
+++ b/mav_planning_rviz/src/planning_interactive_markers.cpp
@@ -2,13 +2,6 @@
 
 #include <functional>
 
-//! @todo(srmainwaring) enable to check headers from mav_msgs are valid
-// #include <mav_msgs/common.hpp>
-// #include <mav_msgs/conversions.hpp>
-// #include <mav_msgs/default_topics.hpp>
-// #include <mav_msgs/default_values.hpp>
-// #include <mav_msgs/eigen_mav_msgs.hpp>
-
 using std::placeholders::_1;
 
 namespace mav_planning_rviz {
@@ -69,12 +62,10 @@ void PlanningInteractiveMarkers::createMarkers() {
   marker_prototype_.controls.push_back(control);
 }
 
-void PlanningInteractiveMarkers::enableSetPoseMarker(const mav_msgs::EigenTrajectoryPoint& pose) {
+void PlanningInteractiveMarkers::enableSetPoseMarker(const geometry_msgs::msg::Pose& pose) {
   RCLCPP_INFO_STREAM(node_->get_logger(), "Enable set pose marker");
 
-  geometry_msgs::msg::PoseStamped pose_stamped;
-  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(pose, &pose_stamped);
-  set_pose_marker_.pose = pose_stamped.pose;
+  set_pose_marker_.pose = pose;
 
   marker_server_.insert(set_pose_marker_);
   marker_server_.setCallback(set_pose_marker_.name,
@@ -89,23 +80,19 @@ void PlanningInteractiveMarkers::disableSetPoseMarker() {
   marker_server_.applyChanges();
 }
 
-void PlanningInteractiveMarkers::setPose(const mav_msgs::EigenTrajectoryPoint& pose) {
-  geometry_msgs::msg::PoseStamped pose_stamped;
-  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(pose, &pose_stamped);
-  set_pose_marker_.pose = pose_stamped.pose;
+void PlanningInteractiveMarkers::setPose(const geometry_msgs::msg::Pose& pose) {
+  set_pose_marker_.pose = pose;
   marker_server_.setPose(set_pose_marker_.name, set_pose_marker_.pose);
   marker_server_.applyChanges();
 
-  RCLCPP_INFO_STREAM(node_->get_logger(), "Set pose: " << to_yaml(pose_stamped));
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Set pose: " << to_yaml(pose));
 }
 
 void PlanningInteractiveMarkers::processSetPoseFeedback(
     const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback) {
   if (feedback->event_type == visualization_msgs::msg::InteractiveMarkerFeedback::POSE_UPDATE) {
     if (pose_updated_function_) {
-      mav_msgs::EigenTrajectoryPoint pose;
-      mav_msgs::eigenTrajectoryPointFromPoseMsg(feedback->pose, &pose);
-      pose_updated_function_(pose);
+      pose_updated_function_(feedback->pose);
 
       RCLCPP_INFO_STREAM(node_->get_logger(), "Set pose feedback: " << to_yaml(feedback->pose));
     }
@@ -114,14 +101,11 @@ void PlanningInteractiveMarkers::processSetPoseFeedback(
   marker_server_.applyChanges();
 }
 
-void PlanningInteractiveMarkers::enableMarker(const std::string& id, const mav_msgs::EigenTrajectoryPoint& pose) {
-  geometry_msgs::msg::PoseStamped pose_stamped;
-  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(pose, &pose_stamped);
-
+void PlanningInteractiveMarkers::enableMarker(const std::string& id, const geometry_msgs::msg::Pose& pose) {
   auto search = marker_map_.find(id);
   if (search != marker_map_.end()) {
     // Already exists, just update the pose and enable it.
-    search->second.pose = pose_stamped.pose;
+    search->second.pose = pose;
     marker_server_.insert(search->second);
     marker_server_.applyChanges();
     return;
@@ -131,24 +115,22 @@ void PlanningInteractiveMarkers::enableMarker(const std::string& id, const mav_m
   marker_map_[id] = marker_prototype_;
   marker_map_[id].name = id;
   marker_map_[id].controls[0].markers[1].text = id;
-  marker_map_[id].pose = pose_stamped.pose;
+  marker_map_[id].pose = pose;
   marker_server_.insert(marker_map_[id]);
   marker_server_.applyChanges();
 }
 
-void PlanningInteractiveMarkers::updateMarkerPose(const std::string& id, const mav_msgs::EigenTrajectoryPoint& pose) {
+void PlanningInteractiveMarkers::updateMarkerPose(const std::string& id, const geometry_msgs::msg::Pose& pose) {
   auto search = marker_map_.find(id);
   if (search == marker_map_.end()) {
     return;
   }
 
-  geometry_msgs::msg::PoseStamped pose_stamped;
-  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(pose, &pose_stamped);
-  search->second.pose = pose_stamped.pose;
-  marker_server_.setPose(id, pose_stamped.pose);
+  search->second.pose = pose;
+  marker_server_.setPose(id, pose);
   marker_server_.applyChanges();
 
-  RCLCPP_INFO_STREAM(node_->get_logger(), "Update marker pose: " << to_yaml(pose_stamped));
+  RCLCPP_INFO_STREAM(node_->get_logger(), "Update marker pose: " << to_yaml(pose));
 }
 
 void PlanningInteractiveMarkers::disableMarker(const std::string& id) {

--- a/mav_planning_rviz/src/planning_panel.cpp
+++ b/mav_planning_rviz/src/planning_panel.cpp
@@ -1,51 +1,40 @@
 #include "mav_planning_rviz/planning_panel.h"
 
-#include <stdio.h>
-
 #include <QCheckBox>
 #include <QComboBox>
 #include <QGridLayout>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
-#include <QPainter>
-#include <QTimer>
+#include <QPushButton>
 #include <QVBoxLayout>
 #include <functional>
-#include <geometry_msgs/msg/twist.hpp>
 #include <thread>
-// #include <mav_planning_msgs/PlannerService.h>
-// #include <ros/names.h>
+
 #include <mavros_msgs/srv/set_mode.hpp>
-#include <planner_msgs/msg/navigation_status.hpp>
 #include <planner_msgs/srv/set_planner_state.hpp>
 #include <planner_msgs/srv/set_service.hpp>
 #include <planner_msgs/srv/set_string.hpp>
 #include <planner_msgs/srv/set_vector3.hpp>
 #include <rviz_common/visualization_manager.hpp>
-#include <std_srvs/srv/empty.hpp>
 
-#include "mav_planning_rviz/edit_button.h"
 #include "mav_planning_rviz/goal_marker.h"
-#include "mav_planning_rviz/pose_widget.h"
 
 using std::placeholders::_1;
 using namespace std::chrono_literals;
 
 namespace mav_planning_rviz {
 
-// utility to convert flight stack string to enum.
+namespace {
+
 FLIGHT_STACK to_flight_stack(const std::string& str) {
-  FLIGHT_STACK flight_stack = FLIGHT_STACK_NONE;
   if (str == "px4") {
-    flight_stack = PX4;
+    return PX4;
   } else if (str == "ardupilot") {
-    flight_stack = ARDUPILOT;
+    return ARDUPILOT;
   }
-  return flight_stack;
+  return FLIGHT_STACK_NONE;
 }
 
-// utility to convert flight stack enum to string.
 std::string to_string(FLIGHT_STACK flight_stack) {
   switch (flight_stack) {
     case PX4:
@@ -57,6 +46,8 @@ std::string to_string(FLIGHT_STACK flight_stack) {
       return "none";
   }
 }
+
+}  // namespace
 
 PlanningPanel::PlanningPanel(QWidget* parent)
     : rviz_common::Panel(parent),
@@ -74,25 +65,16 @@ void PlanningPanel::onInitialize() {
 
   interactive_markers_.initialize();
   interactive_markers_.setPoseUpdatedCallback(std::bind(&PlanningPanel::updateInteractiveMarkerPose, this, _1));
-
   interactive_markers_.setFrameId(getDisplayContext()->getFixedFrame().toStdString());
-  // Initialize all the markers.
-  for (const auto& kv : pose_widget_map_) {
-    geometry_msgs::msg::Pose pose;
-    kv.second->getPose(&pose);
-    interactive_markers_.enableMarker(kv.first, pose);
-  }
 }
 
 void PlanningPanel::createLayout() {
   QGridLayout* service_layout = new QGridLayout;
 
-  // Planner services and publications.
   service_layout->addWidget(createTerrainLoaderGroup(), 0, 0, 1, 1);
   service_layout->addWidget(createPlannerCommandGroup(), 1, 0, 1, 1);
   service_layout->addWidget(createPlannerModeGroup(), 2, 0, 4, 1);
 
-  // First the names, then the start/goal, then service buttons.
   QVBoxLayout* layout = new QVBoxLayout;
   layout->addLayout(service_layout);
   setLayout(layout);
@@ -101,6 +83,7 @@ void PlanningPanel::createLayout() {
 QGroupBox* PlanningPanel::createPlannerModeGroup() {
   QGroupBox* groupBox = new QGroupBox(tr("Planner Actions"));
   QGridLayout* service_layout = new QGridLayout;
+
   set_planner_state_buttons_.push_back(new QPushButton("NAVIGATE"));
   set_planner_state_buttons_.push_back(new QPushButton("ROLLOUT"));
   set_planner_state_buttons_.push_back(new QPushButton("ABORT"));
@@ -130,36 +113,31 @@ QGroupBox* PlanningPanel::createPlannerCommandGroup() {
   set_current_loiter_button_ = new QPushButton("Loiter Start");
   set_current_segment_button_ = new QPushButton("Current Segment");
   trigger_planning_button_ = new QPushButton("Plan");
-  update_path_button_ = new QPushButton("Update Path");
   planning_budget_editor_ = new QLineEdit;
   max_altitude_button_enable_ = new QPushButton("Enable Max altitude");
   max_altitude_button_disable_ = new QPushButton("Disable Max altitude");
-
   waypoint_button_ = new QPushButton("Disengage Planner");
-  controller_button_ = new QPushButton("Send To Controller");
 
-  // Input the namespace.
   service_layout->addWidget(set_start_button_, 0, 0, 1, 1);
   service_layout->addWidget(set_goal_button_, 0, 1, 1, 1);
-
   service_layout->addWidget(set_current_loiter_button_, 0, 2, 1, 1);
   service_layout->addWidget(set_current_segment_button_, 0, 3, 1, 1);
 
   service_layout->addWidget(new QLabel("Planning budget:"), 2, 0, 1, 1);
   service_layout->addWidget(planning_budget_editor_, 2, 1, 1, 1);
   service_layout->addWidget(trigger_planning_button_, 2, 2, 1, 2);
+
   service_layout->addWidget(new QLabel("Max Altitude Constraints:"), 3, 0, 1, 1);
   service_layout->addWidget(max_altitude_button_enable_, 3, 1, 1, 1);
   service_layout->addWidget(max_altitude_button_disable_, 3, 2, 1, 1);
+
   service_layout->addWidget(planner_service_button_, 4, 0, 1, 2);
   service_layout->addWidget(waypoint_button_, 4, 2, 1, 2);
 
   groupBox->setLayout(service_layout);
 
-  // Hook up connections.
   connect(planner_service_button_, SIGNAL(released()), this, SLOT(callPlannerService()));
   connect(set_goal_button_, SIGNAL(released()), this, SLOT(setGoalService()));
-  connect(update_path_button_, SIGNAL(released()), this, SLOT(setPathService()));
   connect(set_start_button_, SIGNAL(released()), this, SLOT(setStartService()));
   connect(set_current_loiter_button_, SIGNAL(released()), this, SLOT(setStartLoiterService()));
   connect(set_current_segment_button_, SIGNAL(released()), this, SLOT(setCurrentSegmentService()));
@@ -168,8 +146,6 @@ QGroupBox* PlanningPanel::createPlannerCommandGroup() {
   connect(trigger_planning_button_, SIGNAL(released()), this, SLOT(setPlanningBudgetService()));
   connect(max_altitude_button_enable_, SIGNAL(released()), this, SLOT(EnableMaxAltitude()));
   connect(max_altitude_button_disable_, SIGNAL(released()), this, SLOT(DisableMaxAltitude()));
-  connect(controller_button_, SIGNAL(released()), this, SLOT(publishToController()));
-  connect(terrain_align_checkbox_, SIGNAL(stateChanged(int)), this, SLOT(terrainAlignmentStateChanged(int)));
 
   return groupBox;
 }
@@ -177,7 +153,7 @@ QGroupBox* PlanningPanel::createPlannerCommandGroup() {
 QGroupBox* PlanningPanel::createTerrainLoaderGroup() {
   QGroupBox* groupBox = new QGroupBox(tr("Terrain Loader"));
   QGridLayout* service_layout = new QGridLayout;
-  // Input the namespace.
+
   service_layout->addWidget(new QLabel("Terrain Location:"), 0, 0, 1, 1);
   planner_name_editor_ = new QLineEdit;
   service_layout->addWidget(planner_name_editor_, 0, 1, 1, 1);
@@ -194,47 +170,18 @@ QGroupBox* PlanningPanel::createTerrainLoaderGroup() {
   connect(planner_name_editor_, SIGNAL(editingFinished()), this, SLOT(updatePlannerName()));
   connect(load_terrain_button_, SIGNAL(released()), this, SLOT(setPlannerName()));
   connect(flight_stack_combobox_, SIGNAL(currentIndexChanged(int)), this, SLOT(updateFlightStack()));
+  connect(terrain_align_checkbox_, SIGNAL(stateChanged(int)), this, SLOT(terrainAlignmentStateChanged(int)));
 
   groupBox->setLayout(service_layout);
-
   return groupBox;
 }
 
 void PlanningPanel::terrainAlignmentStateChanged(int state) {
-  if (state == 0) {
-    align_terrain_on_load_ = 1;
-  } else {
-    align_terrain_on_load_ = 0;
-  }
-}
-
-// Set the topic name we are publishing to.
-void PlanningPanel::setNamespace(const QString& new_namespace) {
-  RCLCPP_DEBUG_STREAM(node_->get_logger(),
-                      "Setting namespace from: " << namespace_.toStdString() << " to " << new_namespace.toStdString());
-  // Only take action if the name has changed.
-  if (new_namespace != namespace_) {
-    namespace_ = new_namespace;
-    Q_EMIT configChanged();
-
-    std::string error;
-    //! @todo(srmainwaring) port to ROS 2
-    // if (ros::names::validate(namespace_.toStdString(), error))
-    {
-      waypoint_pub_ =
-          node_->create_publisher<geometry_msgs::msg::PoseStamped>(namespace_.toStdString() + "/waypoint", 1);
-      controller_pub_ =
-          node_->create_publisher<geometry_msgs::msg::PoseStamped>(namespace_.toStdString() + "/command/pose", 1);
-      odometry_sub_ = node_->create_subscription<nav_msgs::msg::Odometry>(
-          namespace_.toStdString() + "/" + odometry_topic_.toStdString(), 1,
-          std::bind(&PlanningPanel::odometryCallback, this, _1));
-    }
-  }
+  align_terrain_on_load_ = (state == 0);
 }
 
 void PlanningPanel::updatePlannerName() {
   QString new_planner_name = planner_name_editor_->text();
-  std::cout << "New Terrain name: " << new_planner_name.toStdString() << std::endl;
   if (new_planner_name != planner_name_) {
     planner_name_ = new_planner_name;
     Q_EMIT configChanged();
@@ -243,7 +190,6 @@ void PlanningPanel::updatePlannerName() {
 
 void PlanningPanel::updateFlightStack() {
   std::string flight_stack_name = flight_stack_combobox_->currentText().toStdString();
-  std::cout << "Using flight stack: " << flight_stack_name << std::endl;
   FLIGHT_STACK new_flight_stack = to_flight_stack(flight_stack_name);
   if (new_flight_stack != flight_stack_) {
     flight_stack_ = new_flight_stack;
@@ -251,13 +197,11 @@ void PlanningPanel::updateFlightStack() {
   }
 }
 
-// Set the topic name we are publishing to.
 void PlanningPanel::setPlannerName() {
-  std::cout << "[PlanningPanel] Loading new terrain:" << planner_name_.toStdString() << std::endl;
-  // Load new environment using a service
   std::string service_name = "/terrain_planner/set_location";
   std::string new_planner_name = planner_name_.toStdString();
   bool align_terrain = align_terrain_on_load_;
+
   std::thread t([this, service_name, new_planner_name, align_terrain] {
     auto client = node_->create_client<planner_msgs::srv::SetString>(service_name);
     if (!client->wait_for_service(1s)) {
@@ -271,26 +215,17 @@ void PlanningPanel::setPlannerName() {
 
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger, "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
 
-void PlanningPanel::updatePlanningBudget() { setPlanningBudget(planning_budget_editor_->text()); }
+void PlanningPanel::updatePlanningBudget() {
+  setPlanningBudget(planning_budget_editor_->text());
+}
 
 void PlanningPanel::setPlanningBudget(const QString& new_planning_budget) {
   if (new_planning_budget != planning_budget_value_) {
@@ -298,88 +233,14 @@ void PlanningPanel::setPlanningBudget(const QString& new_planning_budget) {
     Q_EMIT configChanged();
   }
 }
-// void PlanningPanel::updateOdometryTopic() { setOdometryTopic(odometry_topic_editor_->text()); }
 
-// Set the topic name we are publishing to.
-void PlanningPanel::setOdometryTopic(const QString& new_odometry_topic) {
-  // Only take action if the name has changed.
-  if (new_odometry_topic != odometry_topic_) {
-    odometry_topic_ = new_odometry_topic;
-    Q_EMIT configChanged();
-
-    std::string error;
-    //! @todo(srmainwaring) port to ROS 2
-    // if (ros::names::validate(namespace_.toStdString(), error))
-    {
-      odometry_sub_ = node_->create_subscription<nav_msgs::msg::Odometry>(
-          namespace_.toStdString() + "/" + odometry_topic_.toStdString(), 1,
-          std::bind(&PlanningPanel::odometryCallback, this, _1));
-    }
-  }
-}
-
-void PlanningPanel::startEditing(const std::string& id) {
-  // Make sure nothing else is being edited.
-  if (!currently_editing_.empty()) {
-    auto search = edit_button_map_.find(currently_editing_);
-    if (search != edit_button_map_.end()) {
-      search->second->finishEditing();
-    }
-  }
-  currently_editing_ = id;
-  // Get the current pose:
-  auto search = pose_widget_map_.find(currently_editing_);
-  if (search == pose_widget_map_.end()) {
-    return;
-  }
-  // Update fixed frame (may have changed since last time):
-  interactive_markers_.setFrameId(getDisplayContext()->getFixedFrame().toStdString());
-  geometry_msgs::msg::Pose pose;
-  search->second->getPose(&pose);
-  interactive_markers_.enableSetPoseMarker(pose);
-  interactive_markers_.disableMarker(id);
-}
-
-void PlanningPanel::finishEditing(const std::string& id) {
-  if (currently_editing_ == id) {
-    currently_editing_.clear();
-    interactive_markers_.disableSetPoseMarker();
-  }
-  auto search = pose_widget_map_.find(id);
-  if (search == pose_widget_map_.end()) {
-    return;
-  }
-  rclcpp::spin_some(node_);
-  geometry_msgs::msg::Pose pose;
-  search->second->getPose(&pose);
-  interactive_markers_.enableMarker(id, pose);
-}
-
-void PlanningPanel::registerPoseWidget(PoseWidget* widget) {
-  pose_widget_map_[widget->id()] = widget;
-  connect(widget, SIGNAL(poseUpdated(const std::string&, geometry_msgs::msg::Pose&)), this,
-          SLOT(widgetPoseUpdated(const std::string&, geometry_msgs::msg::Pose&)));
-}
-
-void PlanningPanel::registerEditButton(EditButton* button) {
-  edit_button_map_[button->id()] = button;
-  connect(button, SIGNAL(startedEditing(const std::string&)), this, SLOT(startEditing(const std::string&)));
-  connect(button, SIGNAL(finishedEditing(const std::string&)), this, SLOT(finishEditing(const std::string&)));
-}
-
-// Save all configuration data from this panel to the given
-// Config object.  It is important here that you call save()
-// on the parent class so the class id and panel name get saved.
 void PlanningPanel::save(rviz_common::Config config) const {
   rviz_common::Panel::save(config);
-  config.mapSetValue("namespace", namespace_);
   config.mapSetValue("planner_name", planner_name_);
   config.mapSetValue("planning_budget", planning_budget_value_);
-  config.mapSetValue("odometry_topic", odometry_topic_);
   config.mapSetValue("flight_stack", QString::fromStdString(to_string(flight_stack_)));
 }
 
-// Load all configuration data for this panel from the given Config object.
 void PlanningPanel::load(const rviz_common::Config& config) {
   rviz_common::Panel::load(config);
   if (config.mapGetString("planner_name", &planner_name_)) {
@@ -396,27 +257,13 @@ void PlanningPanel::load(const rviz_common::Config& config) {
   }
 }
 
-void PlanningPanel::updateInteractiveMarkerPose(const geometry_msgs::msg::Pose& pose) {
-  if (currently_editing_.empty()) {
-    return;
-  }
-  auto search = pose_widget_map_.find(currently_editing_);
-  if (search == pose_widget_map_.end()) {
-    return;
-  }
-  search->second->setPose(pose);
-}
-
-void PlanningPanel::widgetPoseUpdated(const std::string& id, geometry_msgs::msg::Pose& pose) {
-  if (currently_editing_ == id) {
-    interactive_markers_.setPose(pose);
-  }
-  interactive_markers_.updateMarkerPose(id, pose);
+void PlanningPanel::updateInteractiveMarkerPose(const geometry_msgs::msg::Pose& /*pose*/) {
+  // Currently unused - placeholder for interactive marker pose updates
 }
 
 void PlanningPanel::callPlannerService() {
   std::string service_name = "/mavros/set_mode";
-  std::cout << "Planner Service" << std::endl;
+
   std::thread t([this, service_name] {
     auto client = node_->create_client<mavros_msgs::srv::SetMode>(service_name);
     if (!client->wait_for_service(1s)) {
@@ -425,7 +272,6 @@ void PlanningPanel::callPlannerService() {
     }
 
     auto req = std::make_shared<mavros_msgs::srv::SetMode::Request>();
-    req->custom_mode = "GUIDED";
     switch (flight_stack_) {
       case PX4:
         req->custom_mode = "OFFBOARD";
@@ -438,58 +284,20 @@ void PlanningPanel::callPlannerService() {
         req->custom_mode = "NONE";
         break;
     }
+
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
 
-void PlanningPanel::callPublishPath() {
-  std::string service_name = namespace_.toStdString() + "/" + planner_name_.toStdString() + "/publish_path";
-  auto client = node_->create_client<std_srvs::srv::Empty>(service_name);
-  if (!client->wait_for_service(1s)) {
-    RCLCPP_WARN_STREAM(node_->get_logger(), "Service [" << service_name << "] not available.");
-    return;
-  }
-
-  auto req = std::make_shared<std_srvs::srv::Empty::Request>();
-
-  auto result = client->async_send_request(req);
-
-  //! @todo(srmainwaring) prevent race condition with async service calls
-  const std::lock_guard<std::mutex> lock(node_mutex_);
-  if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
-    RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-    return;
-  }
-
-  // try {
-  //   if (!ros::service::call(service_name, req)) {
-  //     RCLCPP_WARN_STREAM(node_->get_logger(), "Couldn't call service: " << service_name);
-  //   }
-  // } catch (const std::exception& e) {
-  //   RCLCPP_ERROR_STREAM(node_->get_logger(), "Service Exception: " << e.what());
-  // }
-}
-
 void PlanningPanel::publishWaypoint() {
   std::string service_name = "/mavros/set_mode";
-  std::cout << "Planner Service" << std::endl;
+
   std::thread t([this, service_name] {
     auto client = node_->create_client<mavros_msgs::srv::SetMode>(service_name);
     if (!client->wait_for_service(1s)) {
@@ -510,23 +318,13 @@ void PlanningPanel::publishWaypoint() {
         req->custom_mode = "NONE";
         break;
     }
+
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
@@ -536,12 +334,9 @@ void PlanningPanel::EnableMaxAltitude() { setMaxAltitudeConstrant(true); }
 void PlanningPanel::DisableMaxAltitude() { setMaxAltitudeConstrant(false); }
 
 void PlanningPanel::setMaxAltitudeConstrant(bool set_constraint) {
-  std::cout << "[PlanningPanel] Loading new terrain:" << planner_name_.toStdString() << std::endl;
-  // Load new environment using a service
   std::string service_name = "/terrain_planner/set_max_altitude";
-  std::string new_planner_name = "";
-  bool align_terrain = set_constraint;
-  std::thread t([this, service_name, new_planner_name, align_terrain] {
+
+  std::thread t([this, service_name, set_constraint] {
     auto client = node_->create_client<planner_msgs::srv::SetString>(service_name);
     if (!client->wait_for_service(1s)) {
       RCLCPP_WARN_STREAM(node_->get_logger(), "Service [" << service_name << "] not available.");
@@ -549,26 +344,15 @@ void PlanningPanel::setMaxAltitudeConstrant(bool set_constraint) {
     }
 
     auto req = std::make_shared<planner_msgs::srv::SetString::Request>();
-    req->string = new_planner_name;
-    req->align = align_terrain;
+    req->string = "";
+    req->align = set_constraint;
 
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
@@ -576,11 +360,8 @@ void PlanningPanel::setMaxAltitudeConstrant(bool set_constraint) {
 void PlanningPanel::setGoalService() {
   std::string service_name = "/terrain_planner/set_goal";
   Eigen::Vector3d goal_pos = goal_marker_->getGoalPosition();
-  // The altitude is set as a terrain altitude of the goal point. Therefore, passing negative terrain altitude
-  // invalidates the altitude setpoint
-  double goal_altitude{-1.0};
 
-  std::thread t([this, service_name, goal_pos, goal_altitude] {
+  std::thread t([this, service_name, goal_pos] {
     auto client = node_->create_client<planner_msgs::srv::SetVector3>(service_name);
     if (!client->wait_for_service(1s)) {
       RCLCPP_WARN_STREAM(node_->get_logger(), "Service [" << service_name << "] not available.");
@@ -590,73 +371,27 @@ void PlanningPanel::setGoalService() {
     auto req = std::make_shared<planner_msgs::srv::SetVector3::Request>();
     req->vector.x = goal_pos(0);
     req->vector.y = goal_pos(1);
-    req->vector.z = goal_altitude;
+    req->vector.z = -1.0;  // Negative altitude invalidates the altitude setpoint
 
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
-  });
-  t.detach();
-}
-
-void PlanningPanel::setPathService() {
-  std::string service_name = "/terrain_planner/set_path";
-  std::cout << "Planner Service" << std::endl;
-  std::thread t([this, service_name] {
-    auto client = node_->create_client<planner_msgs::srv::SetVector3>(service_name);
-    if (!client->wait_for_service(1s)) {
-      RCLCPP_WARN_STREAM(node_->get_logger(), "Service [" << service_name << "] not available.");
-      return;
-    }
-
-    auto req = std::make_shared<planner_msgs::srv::SetVector3::Request>();
-
-    auto result = client->async_send_request(req);
-
-    //! @todo(srmainwaring) prevent race condition with async service calls
-    const std::lock_guard<std::mutex> lock(node_mutex_);
-    if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
-      RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
-    }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
 
 void PlanningPanel::setPlanningBudgetService() {
   std::string service_name = "/terrain_planner/trigger_planning";
-  // The altitude is set as a terrain altitude of the goal point. Therefore, passing negative terrain altitude
-  // invalidates the altitude setpoint
-  double planning_budget{-1.0};
+  double planning_budget = -1.0;
 
   try {
     planning_budget = std::stod(planning_budget_value_.toStdString());
-    std::cout << "[PlanningPanel] Set Planning Budget: " << planning_budget << std::endl;
   } catch (const std::exception& e) {
-    std::cout << "[PlanningPanel] InvalidPlanning Budget: " << e.what() << std::endl;
+    RCLCPP_WARN_STREAM(node_->get_logger(), "Invalid planning budget: " << e.what());
+    return;
   }
 
   std::thread t([this, service_name, planning_budget] {
@@ -667,44 +402,32 @@ void PlanningPanel::setPlanningBudgetService() {
     }
 
     auto req = std::make_shared<planner_msgs::srv::SetVector3::Request>();
-    // if ()
     req->vector.z = planning_budget;
 
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
 
 void PlanningPanel::setPlannerModeServiceNavigate() {
-  callSetPlannerStateService("/terrain_planner/set_planner_state", 2);
+  callSetPlannerStateService("/terrain_planner/set_planner_state", NAVIGATE);
 }
 
 void PlanningPanel::setPlannerModeServiceAbort() {
-  callSetPlannerStateService("/terrain_planner/set_planner_state", 4);
+  callSetPlannerStateService("/terrain_planner/set_planner_state", ABORT);
 }
 
 void PlanningPanel::setPlannerModeServiceReturn() {
-  callSetPlannerStateService("/terrain_planner/set_planner_state", 5);
+  callSetPlannerStateService("/terrain_planner/set_planner_state", RETURN);
 }
 
 void PlanningPanel::setPlannerModeServiceRollout() {
-  callSetPlannerStateService("/terrain_planner/set_planner_state", 3);
+  callSetPlannerStateService("/terrain_planner/set_planner_state", ROLLOUT);
 }
 
 void PlanningPanel::callSetPlannerStateService(std::string service_name, const int mode) {
@@ -720,21 +443,10 @@ void PlanningPanel::callSetPlannerStateService(std::string service_name, const i
 
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
@@ -742,11 +454,8 @@ void PlanningPanel::callSetPlannerStateService(std::string service_name, const i
 void PlanningPanel::setStartService() {
   std::string service_name = "/terrain_planner/set_start";
   Eigen::Vector3d goal_pos = goal_marker_->getGoalPosition();
-  // The altitude is set as a terrain altitude of the goal point. Therefore, passing negative terrain altitude
-  // invalidates the altitude setpoint
-  double goal_altitude{-1.0};
 
-  std::thread t([this, service_name, goal_pos, goal_altitude] {
+  std::thread t([this, service_name, goal_pos] {
     auto client = node_->create_client<planner_msgs::srv::SetVector3>(service_name);
     if (!client->wait_for_service(1s)) {
       RCLCPP_WARN_STREAM(node_->get_logger(), "Service [" << service_name << "] not available.");
@@ -756,25 +465,14 @@ void PlanningPanel::setStartService() {
     auto req = std::make_shared<planner_msgs::srv::SetVector3::Request>();
     req->vector.x = goal_pos(0);
     req->vector.y = goal_pos(1);
-    req->vector.z = goal_altitude;
+    req->vector.z = -1.0;  // Negative altitude invalidates the altitude setpoint
 
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
@@ -790,24 +488,12 @@ void PlanningPanel::setStartLoiterService() {
     }
 
     auto req = std::make_shared<planner_msgs::srv::SetService::Request>();
-
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
@@ -823,93 +509,56 @@ void PlanningPanel::setCurrentSegmentService() {
     }
 
     auto req = std::make_shared<planner_msgs::srv::SetService::Request>();
-
     auto result = client->async_send_request(req);
 
-    //! @todo(srmainwaring) prevent race condition with async service calls
     const std::lock_guard<std::mutex> lock(node_mutex_);
     if (rclcpp::spin_until_future_complete(node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
       RCLCPP_ERROR_STREAM(node_->get_logger(), "Call to service [" << client->get_service_name() << "] failed.");
-      return;
     }
-
-    // try {
-    //   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Service name: " << service_name);
-    //   if (!ros::service::call(service_name, req)) {
-    //     std::cout << "Couldn't call service: " << service_name << std::endl;
-    //   }
-    // } catch (const std::exception& e) {
-    //   std::cout << "Service Exception: " << e.what() << std::endl;
-    // }
   });
   t.detach();
 }
 
-void PlanningPanel::publishToController() {
-  geometry_msgs::msg::Pose goal_pose;
-  goal_pose_widget_->getPose(&goal_pose);
-
-  geometry_msgs::msg::PoseStamped pose_stamped;
-  pose_stamped.header.frame_id = getDisplayContext()->getFixedFrame().toStdString();
-  pose_stamped.pose = goal_pose;
-
-  RCLCPP_DEBUG_STREAM(node_->get_logger(), "Publishing controller goal on "
-                                               << controller_pub_->get_topic_name()
-                                               << " subscribers: " << controller_pub_->get_subscription_count());
-
-  controller_pub_->publish(pose_stamped);
-}
-
-void PlanningPanel::odometryCallback(const nav_msgs::msg::Odometry& msg) {
-  RCLCPP_INFO_ONCE(node_->get_logger(), "Got odometry callback.");
-  if (align_terrain_on_load_) {
-    geometry_msgs::msg::Pose pose = msg.pose.pose;
-    pose_widget_map_["start"]->setPose(pose);
-    interactive_markers_.updateMarkerPose("start", pose);
-  }
+void PlanningPanel::odometryCallback(const nav_msgs::msg::Odometry& /*msg*/) {
+  // Currently unused - placeholder for odometry updates
 }
 
 void PlanningPanel::plannerstateCallback(const planner_msgs::msg::NavigationStatus& msg) {
   switch (msg.state) {
-    case PLANNER_STATE::HOLD: {
+    case PLANNER_STATE::HOLD:
       set_planner_state_buttons_[0]->setDisabled(false);  // NAVIGATE
       set_planner_state_buttons_[1]->setDisabled(false);  // ROLLOUT
       set_planner_state_buttons_[2]->setDisabled(true);   // ABORT
       set_planner_state_buttons_[3]->setDisabled(false);  // RETURN
       break;
-    }
-    case PLANNER_STATE::NAVIGATE: {
+    case PLANNER_STATE::NAVIGATE:
       set_planner_state_buttons_[0]->setDisabled(true);   // NAVIGATE
       set_planner_state_buttons_[1]->setDisabled(true);   // ROLLOUT
       set_planner_state_buttons_[2]->setDisabled(false);  // ABORT
       set_planner_state_buttons_[3]->setDisabled(false);  // RETURN
       break;
-    }
-    case PLANNER_STATE::ROLLOUT: {
+    case PLANNER_STATE::ROLLOUT:
       set_planner_state_buttons_[0]->setDisabled(true);   // NAVIGATE
       set_planner_state_buttons_[1]->setDisabled(true);   // ROLLOUT
       set_planner_state_buttons_[2]->setDisabled(false);  // ABORT
       set_planner_state_buttons_[3]->setDisabled(true);   // RETURN
       break;
-    }
-    case PLANNER_STATE::ABORT: {
+    case PLANNER_STATE::ABORT:
       set_planner_state_buttons_[0]->setDisabled(true);  // NAVIGATE
       set_planner_state_buttons_[1]->setDisabled(true);  // ROLLOUT
       set_planner_state_buttons_[2]->setDisabled(true);  // ABORT
       set_planner_state_buttons_[3]->setDisabled(true);  // RETURN
       break;
-    }
-    case PLANNER_STATE::RETURN: {
+    case PLANNER_STATE::RETURN:
       set_planner_state_buttons_[0]->setDisabled(true);   // NAVIGATE
       set_planner_state_buttons_[1]->setDisabled(true);   // ROLLOUT
       set_planner_state_buttons_[2]->setDisabled(false);  // ABORT
       set_planner_state_buttons_[3]->setDisabled(true);   // RETURN
       break;
-    }
   }
 }
 
 }  // namespace mav_planning_rviz
 
-#include <pluginlib/class_list_macros.hpp>  // NOLINT
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(mav_planning_rviz::PlanningPanel, rviz_common::Panel)

--- a/mav_planning_rviz/src/planning_panel.cpp
+++ b/mav_planning_rviz/src/planning_panel.cpp
@@ -78,7 +78,7 @@ void PlanningPanel::onInitialize() {
   interactive_markers_.setFrameId(getDisplayContext()->getFixedFrame().toStdString());
   // Initialize all the markers.
   for (const auto& kv : pose_widget_map_) {
-    mav_msgs::EigenTrajectoryPoint pose;
+    geometry_msgs::msg::Pose pose;
     kv.second->getPose(&pose);
     interactive_markers_.enableMarker(kv.first, pose);
   }
@@ -334,7 +334,7 @@ void PlanningPanel::startEditing(const std::string& id) {
   }
   // Update fixed frame (may have changed since last time):
   interactive_markers_.setFrameId(getDisplayContext()->getFixedFrame().toStdString());
-  mav_msgs::EigenTrajectoryPoint pose;
+  geometry_msgs::msg::Pose pose;
   search->second->getPose(&pose);
   interactive_markers_.enableSetPoseMarker(pose);
   interactive_markers_.disableMarker(id);
@@ -350,15 +350,15 @@ void PlanningPanel::finishEditing(const std::string& id) {
     return;
   }
   rclcpp::spin_some(node_);
-  mav_msgs::EigenTrajectoryPoint pose;
+  geometry_msgs::msg::Pose pose;
   search->second->getPose(&pose);
   interactive_markers_.enableMarker(id, pose);
 }
 
 void PlanningPanel::registerPoseWidget(PoseWidget* widget) {
   pose_widget_map_[widget->id()] = widget;
-  connect(widget, SIGNAL(poseUpdated(const std::string&, mav_msgs::EigenTrajectoryPoint&)), this,
-          SLOT(widgetPoseUpdated(const std::string&, mav_msgs::EigenTrajectoryPoint&)));
+  connect(widget, SIGNAL(poseUpdated(const std::string&, geometry_msgs::msg::Pose&)), this,
+          SLOT(widgetPoseUpdated(const std::string&, geometry_msgs::msg::Pose&)));
 }
 
 void PlanningPanel::registerEditButton(EditButton* button) {
@@ -396,7 +396,7 @@ void PlanningPanel::load(const rviz_common::Config& config) {
   }
 }
 
-void PlanningPanel::updateInteractiveMarkerPose(const mav_msgs::EigenTrajectoryPoint& pose) {
+void PlanningPanel::updateInteractiveMarkerPose(const geometry_msgs::msg::Pose& pose) {
   if (currently_editing_.empty()) {
     return;
   }
@@ -407,7 +407,7 @@ void PlanningPanel::updateInteractiveMarkerPose(const mav_msgs::EigenTrajectoryP
   search->second->setPose(pose);
 }
 
-void PlanningPanel::widgetPoseUpdated(const std::string& id, mav_msgs::EigenTrajectoryPoint& pose) {
+void PlanningPanel::widgetPoseUpdated(const std::string& id, geometry_msgs::msg::Pose& pose) {
   if (currently_editing_ == id) {
     interactive_markers_.setPose(pose);
   }
@@ -846,30 +846,26 @@ void PlanningPanel::setCurrentSegmentService() {
 }
 
 void PlanningPanel::publishToController() {
-  mav_msgs::EigenTrajectoryPoint goal_point;
-  goal_pose_widget_->getPose(&goal_point);
+  geometry_msgs::msg::Pose goal_pose;
+  goal_pose_widget_->getPose(&goal_pose);
 
-  geometry_msgs::msg::PoseStamped pose;
-  pose.header.frame_id = getDisplayContext()->getFixedFrame().toStdString();
-  mav_msgs::msgPoseStampedFromEigenTrajectoryPoint(goal_point, &pose);
+  geometry_msgs::msg::PoseStamped pose_stamped;
+  pose_stamped.header.frame_id = getDisplayContext()->getFixedFrame().toStdString();
+  pose_stamped.pose = goal_pose;
 
   RCLCPP_DEBUG_STREAM(node_->get_logger(), "Publishing controller goal on "
                                                << controller_pub_->get_topic_name()
                                                << " subscribers: " << controller_pub_->get_subscription_count());
 
-  controller_pub_->publish(pose);
+  controller_pub_->publish(pose_stamped);
 }
 
 void PlanningPanel::odometryCallback(const nav_msgs::msg::Odometry& msg) {
   RCLCPP_INFO_ONCE(node_->get_logger(), "Got odometry callback.");
   if (align_terrain_on_load_) {
-    mav_msgs::EigenOdometry odometry;
-    mav_msgs::eigenOdometryFromMsg(msg, &odometry);
-    mav_msgs::EigenTrajectoryPoint point;
-    point.position_W = odometry.position_W;
-    point.orientation_W_B = odometry.orientation_W_B;
-    pose_widget_map_["start"]->setPose(point);
-    interactive_markers_.updateMarkerPose("start", point);
+    geometry_msgs::msg::Pose pose = msg.pose.pose;
+    pose_widget_map_["start"]->setPose(pose);
+    interactive_markers_.updateMarkerPose("start", pose);
   }
 }
 

--- a/mav_planning_rviz/src/pose_widget.cpp
+++ b/mav_planning_rviz/src/pose_widget.cpp
@@ -5,11 +5,30 @@
 #include <QHeaderView>
 #include <QTableView>
 #include <QTableWidget>
+#include <cmath>
 
 namespace mav_planning_rviz {
 
 constexpr double kDegToRad = M_PI / 180.0;
 constexpr double kRadToDeg = 180.0 / M_PI;
+
+namespace {
+
+// Helper to extract yaw from quaternion
+double getYawFromQuaternion(const geometry_msgs::msg::Quaternion& q) {
+  return std::atan2(2.0 * (q.w * q.z + q.x * q.y),
+                    1.0 - 2.0 * (q.y * q.y + q.z * q.z));
+}
+
+// Helper to set quaternion from yaw
+void setQuaternionFromYaw(double yaw, geometry_msgs::msg::Quaternion* q) {
+  q->w = std::cos(yaw / 2.0);
+  q->x = 0.0;
+  q->y = 0.0;
+  q->z = std::sin(yaw / 2.0);
+}
+
+}  // namespace
 
 PoseWidget::PoseWidget(const std::string& id, QWidget* parent) : QWidget(parent), id_(id) { createTable(); }
 
@@ -42,26 +61,28 @@ void PoseWidget::createTable() {
   connect(table_widget_, SIGNAL(itemChanged(QTableWidgetItem*)), this, SLOT(itemChanged(QTableWidgetItem*)));
 }
 
-void PoseWidget::getPose(mav_msgs::EigenTrajectoryPoint* point) const {
-  point->position_W.x() = table_widget_->item(0, 0)->text().toDouble();
-  point->position_W.y() = table_widget_->item(0, 1)->text().toDouble();
-  point->position_W.z() = table_widget_->item(0, 2)->text().toDouble();
-  point->setFromYaw(table_widget_->item(0, 3)->text().toDouble() * kDegToRad);
+void PoseWidget::getPose(geometry_msgs::msg::Pose* pose) const {
+  pose->position.x = table_widget_->item(0, 0)->text().toDouble();
+  pose->position.y = table_widget_->item(0, 1)->text().toDouble();
+  pose->position.z = table_widget_->item(0, 2)->text().toDouble();
+  double yaw = table_widget_->item(0, 3)->text().toDouble() * kDegToRad;
+  setQuaternionFromYaw(yaw, &pose->orientation);
 }
 
-void PoseWidget::setPose(const mav_msgs::EigenTrajectoryPoint& point) {
+void PoseWidget::setPose(const geometry_msgs::msg::Pose& pose) {
   table_widget_->blockSignals(true);
-  table_widget_->item(0, 0)->setText(QString::number(point.position_W.x(), 'f', 2));
-  table_widget_->item(0, 1)->setText(QString::number(point.position_W.y(), 'f', 2));
-  table_widget_->item(0, 2)->setText(QString::number(point.position_W.z(), 'f', 2));
-  table_widget_->item(0, 3)->setText(QString::number(point.getYaw() * kRadToDeg, 'f', 2));
+  table_widget_->item(0, 0)->setText(QString::number(pose.position.x, 'f', 2));
+  table_widget_->item(0, 1)->setText(QString::number(pose.position.y, 'f', 2));
+  table_widget_->item(0, 2)->setText(QString::number(pose.position.z, 'f', 2));
+  double yaw = getYawFromQuaternion(pose.orientation);
+  table_widget_->item(0, 3)->setText(QString::number(yaw * kRadToDeg, 'f', 2));
   table_widget_->blockSignals(false);
 }
 
 void PoseWidget::itemChanged(QTableWidgetItem* /*item*/) {
-  mav_msgs::EigenTrajectoryPoint point;
-  getPose(&point);
-  Q_EMIT poseUpdated(id_, point);
+  geometry_msgs::msg::Pose pose;
+  getPose(&pose);
+  Q_EMIT poseUpdated(id_, pose);
 }
 
 QWidget* DoubleTableDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/,

--- a/terrain-navigation.repos
+++ b/terrain-navigation.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/ethz-asl/terrain-navigation.git
     version: ros2
-  ethz-asl/mav_comm:
-    type: git
-    url: https://github.com/ethz-asl/mav_comm.git
-    version: ros2


### PR DESCRIPTION
**Problem Description**
There was a `mav_comm` dependency, which caused a lot of headaches for the ROS 2 port but didn't really provide much utilities. This PR removes it, with some additional cleanup on unused implementation carried over from the ROS 2 port.