### PR TITLE
Handle segfault when using OwenStateSpace from OMPL

### DIFF
--- a/terrain_planner/src/terrain_ompl_rrt.cpp
+++ b/terrain_planner/src/terrain_ompl_rrt.cpp
@@ -387,6 +387,9 @@ void TerrainOmplRrt::solutionPathToPath(ompl::geometric::PathGeometric path, Pat
     auto from = state_vector[idx];    // Start of the segment
     auto to = state_vector[idx + 1];  // End of the segment
     auto dubins_path = problem_setup_->getStateSpace()->as<ompl::base::OwenStateSpace>()->getPath(from, to);
+    if (!dubins_path.has_value()) {
+      continue;
+    }
 
     if (dubins_path->phi_ == 0.) {
       if (dubins_path->numTurns_ == 0) {


### PR DESCRIPTION
**Problem Description**
Occasionally the Dubins interpolation would fail, making the code crash.

Additional context: https://github.com/ompl/ompl/issues/1362

**Proposed Solution**
This checks whether the dubins_path has a value before using it.