### PR TITLE
Use cruise speed for reference velocity

### DIFF
--- a/terrain_navigation_ros/src/terrain_planner.cpp
+++ b/terrain_navigation_ros/src/terrain_planner.cpp
@@ -1120,7 +1120,7 @@ void TerrainPlanner::generateCircle(const Eigen::Vector3d end_position, const Ei
   Eigen::Vector3d radial_vector = (end_position - center_pos);
   radial_vector(2) = 0.0;  // Only consider horizontal loiters
   Eigen::Vector3d emergency_rates =
-      20.0 * end_velocity.normalized().cross(radial_vector.normalized()) / radial_vector.norm();
+      cruise_speed_ * end_velocity.normalized().cross(radial_vector.normalized()) / radial_vector.norm();
   double horizon = 2 * M_PI / std::abs(emergency_rates(2));
   // Append a loiter at the end of the planned path
   trajectory = generateArcTrajectory(emergency_rates, horizon, end_position, end_velocity);


### PR DESCRIPTION
**Problem Description**
There was a bug on the circular path generation, where the cruise speed was hard coded in the implementation.

**Solution**
This PR makes the path generation use the ros parameter configured variable

To reproduce, you can run the following commands.
```
ros2 launch terrain_navigation_ros sitl.launch.py
```

**Before PR**
<img width="3117" height="1976" alt="rviz_screenshot_2026_06_10-13_07_52" src="https://github.com/user-attachments/assets/2d27a1b5-1726-4f24-90f8-dd69e0dc90f3" />

**After PR**
<img width="3117" height="1976" alt="rviz_screenshot_2026_06_10-13_33_14" src="https://github.com/user-attachments/assets/0dbbb1ce-ba4e-44e6-a22c-2fa50d9b32f7" />
